### PR TITLE
DFPlayer, UART, and TIM2 Updates

### DIFF
--- a/include/DFPlayer_config.h
+++ b/include/DFPlayer_config.h
@@ -1,0 +1,16 @@
+/*
+ * DFPlayer_config.h
+ *
+ *  Created on: May 16, 2025
+ *      Author: elwady
+ */
+
+#ifndef DFPLAYER_CONFIG_H_
+#define DFPLAYER_CONFIG_H_
+
+#define DFPlayer_Port	PORTA
+#define Busy_Pin		PIN0
+
+
+
+#endif /* DFPLAYER_CONFIG_H_ */

--- a/include/DFPlayer_interface.h
+++ b/include/DFPlayer_interface.h
@@ -1,0 +1,103 @@
+/*
+ * DFPlayer_interface.h
+ *
+ *  Created on: May 16, 2025
+ *      Author: elwady
+ */
+
+#ifndef DFPLAYER_INTERFACE_H_
+#define DFPLAYER_INTERFACE_H_
+
+typedef enum
+{
+	Next=1,
+	Previous,
+	Soecify_Tracking,
+	Increase_Vol,
+	Decrease_Vol,
+	Specify_Vol,
+	Specify_EQ,
+	Specify_Playback_Mode,
+	Specify_Playback_Source,
+	Low_Power_Loss,
+	Normal_Working,
+	Reset_Module,
+	Play,
+	Pause,
+	Specify_Folder,
+	Volume_Adjust,
+	Repeat_Play
+}CMDs;
+
+typedef enum
+{
+	Stay1=0x3C,
+	Stay2,
+	Stay3,
+	Send_initialization,
+	request_retransmission,
+	Reply,
+	current_status,
+	current_volume,
+	current_EQ,
+	current_playback_mode,
+	current_software_version,
+	number_of_Card_Files,
+	number_of_Disk_Files,
+	number_of_Flash_Files,
+	Keep_on,
+	current_track_of_card,
+	current_track_of_Disk,
+	current_track_of_Flash
+}F_CMDs;
+
+typedef enum
+{
+	U,
+	TF,
+	AUX,
+	Sleep,
+	Flash
+}Playback_Sources;
+
+
+typedef enum
+{
+	Repeat,
+	Folder_Repeat,
+	Single_Repeat,
+	Random_Repeat
+}Playback_Modes;
+
+typedef enum
+{
+	DFPLAYER_EQ_NORMAL,
+	DFPLAYER_EQ_POP,
+	DFPLAYER_EQ_ROCK,
+	DFPLAYER_EQ_JAZZ,
+	DFPLAYER_EQ_CLASSIC,
+	DFPLAYER_EQ_BASS
+}EQ_t;
+
+#define TF_Card_online					1
+#define Pause_status_and_module_sleep	2
+#define Playback_Status					3
+
+#define DFPLAYER_RECEIVED_LENGTH 10
+#define DFPLAYER_SEND_LENGTH 10
+
+#define DFPLAYER_START_BYTE     0x7E
+#define DFPLAYER_VERSION        0xFF
+#define DFPLAYER_CMD_LENGTH     0x06
+#define DFPLAYER_END_BYTE       0xEF
+
+u8_t Received[DFPLAYER_RECEIVED_LENGTH];
+//uint8_t Sending[DFPLAYER_SEND_LENGTH];
+
+void DFPlayer_Init(void);
+void DFPlayer_Send_Stack(u8_t CMD,u8_t FeedBack,u16_t Para);
+u8_t DFPlayer_Receive_Stack(u8_t *response);
+u8_t DFPlayer_Validate_Stack(u8_t *received);
+u16_t DFPlayer_Parse(u8_t *Frame);
+u8_t DFPlayer_Get_Busy_State(void);
+#endif /* DFPLAYER_INTERFACE_H_ */

--- a/include/RCC_interface.h
+++ b/include/RCC_interface.h
@@ -27,6 +27,7 @@ typedef enum {
     PERIPH_SPI2,
     PERIPH_SPI3,
     PERIPH_USART2,
+	PERIPH_TIM2,
     PERIPH_USART1,
     PERIPH_USART6,
     PERIPH_SPI1,
@@ -46,6 +47,7 @@ typedef enum {
 #define SPI2   14
 #define SPI3   15
 #define USART2 17
+#define TIM2	0
 
 /*****APB2 BUS*****/
 #define USART1  4

--- a/include/TIM2_config.h
+++ b/include/TIM2_config.h
@@ -21,6 +21,6 @@
  * SET prescalar value from 1 -> 65536
  * Calculation -> fosc/[PRESCALAR]-1
  */
-#define PRESCALAR 8
+#define PRESCALAR 15
 
 #endif /* TIM2_CONFIG_H_ */

--- a/include/TIM2_interface.h
+++ b/include/TIM2_interface.h
@@ -16,5 +16,7 @@ void TIM2_Call_Back_Function(void (*ptr)(void));
 void TIM2_Preload_Value(u32_t PRELOAD);
 void TIM2_Clear_Interrupt_Flag();
 u8_t TIM2_Read_Interrupt_Flag();
+void TIM2_Delay_ms(u32_t Load);
+void TIM2_Delay_us(u32_t Load);
 
 #endif /* TIM2_INTERFACE_H_ */

--- a/include/TIM2_private.h
+++ b/include/TIM2_private.h
@@ -45,6 +45,7 @@ typedef struct
 #define UIE 0
 #define UIF 0
 #define UG 0
+#define OPM 3
 
 #define TIM2_UPCOUNT   0
 #define TIM2_DOWNCOUNT 1

--- a/src/DFPlayer_program.c
+++ b/src/DFPlayer_program.c
@@ -1,0 +1,128 @@
+#include "STD_TYPE.h"
+#include "BIT_MATH.h"
+#include "UART_interface.h"
+#include "UART_private.h"
+#include "DFPlayer_interface.h"
+#include "TIM2_interface.h"
+#include "RCC_interface.h"
+#include "SYSTICK_interface.h"
+#include "DFPlayer_config.h"
+
+void DFPlayer_Init(void)
+{
+	//init rcc for timer2
+	RCC_Peripheral_CLK_Enable(PERIPH_TIM2);
+	RCC_Peripheral_CLK_Enable(PERIPH_USART1);
+	TIM2_Peripheral_Init();
+	UART1_Peripheral_init();
+
+	//Init Busy Pin
+	GPIO_Set_Mode(DFPlayer_Port,Busy_Pin,INPUT);
+	GPIO_Set_Input_Type(DFPlayer_Port,Busy_Pin,NO_PULL);
+	//to make the module read files
+	DFPlayer_Receive_Stack(Received);
+
+	//Parse Function to extract who is ready
+
+}
+
+void DFPlayer_Send_Stack(u8_t CMD,u8_t FeedBack,u16_t Para)
+{
+	u8_t Sending[DFPLAYER_SEND_LENGTH];
+	u16_t checksum;
+	u16_t sum=0;
+
+	Sending[0] = DFPLAYER_START_BYTE;
+	Sending[1] = DFPLAYER_VERSION;
+	Sending[2] = DFPLAYER_CMD_LENGTH;
+	Sending[3] = CMD;
+	Sending[4] = FeedBack;
+	Sending[5] = (Para >> 8) & 0xFF;   //high byte parameter
+	Sending[6] = Para & 0xFF;		   //Low byte parameter
+
+	for(u8_t i = 1; i <= 6; i++) {
+		sum += Sending[i];
+	}
+
+	checksum = 0xFFFF - sum + 1;
+
+	Sending[7] = (checksum >> 8) & 0xFF;  // High byte checksum
+	Sending[8] = checksum & 0xFF;         // Low byte checksum
+	Sending[9] = 0xEF;                    // End byte
+
+	//Send Frame
+	for (int i = 0; i < 10; i++) {
+		UART1_Send_Data(Sending[i]);
+	}
+}
+
+u8_t DFPlayer_Validate_Stack(u8_t *received)
+{
+	u16_t Theoritical_checksum;
+	u16_t sum=0;
+	u16_t Actual_checksum = (received[7]<<8) | (received[8]);
+
+	for(u8_t i = 1; i <= 6; i++) {
+		sum += received[i];
+	}
+
+	Theoritical_checksum = 0xFFFF - sum + 1;
+
+	return Theoritical_checksum == Actual_checksum;
+}
+
+u8_t DFPlayer_Receive_Stack(u8_t *response)
+{
+	//Receive 10 Byte Data
+	for (u8_t i = 0; i < DFPLAYER_RECEIVED_LENGTH; i++)
+	{
+		response[i] = UART1_Recieve_Data();
+	}
+	//Check Frame Start and end
+	if (response[0] != DFPLAYER_START_BYTE || response[9] != DFPLAYER_END_BYTE)
+	{
+		return 0;  //Wrong Frame
+	}
+	//Check Checksum
+	if (!DFPlayer_Validate_Stack(response))
+	{
+		return 0; // Checksum isn't typical
+	}
+
+	return 1; //Ideal Frame
+}
+
+u16_t DFPlayer_Parse(u8_t *Frame)
+{
+	//Parse CMD and 16bit Parameter
+	u8_t CMD = Frame[3];
+	u16_t Param = (Frame[5]<<8)|(Frame[6]);
+
+	switch (CMD) {
+	case 0x3F: //Returned Data of Module Power-on
+		if(Param == 0x0002) return TF_Card_online;
+	case 0x3D: //Returned Data of Track Finished Playing on TF Card
+		return Param;
+	case 0x3D: //Initialized Device is online
+		if(Param == 0x0002) return TF_Card_online;
+		break;
+	case 0x3F: //Initialized Device is online
+		if(Param == 0x0002) return TF_Card_online;
+		break;
+	default:
+		break;
+	}
+}
+
+u8_t DFPlayer_Get_Busy_State(void)
+{
+	if(READ_BIT(DFPlayer_Port,Busy_Pin) == LOW)
+	{
+		return Pause_status_and_module_sleep;
+	}
+	else if(READ_BIT(DFPlayer_Port,Busy_Pin) == HIGH)
+	{
+		return Playback_Status;
+	}
+}
+

--- a/src/RCC_program.c
+++ b/src/RCC_program.c
@@ -69,6 +69,9 @@ void RCC_Peripheral_CLK_Enable(Peripheral_t enuPeripheral)
         case PERIPH_USART2:
             SET_BIT(RCC->APB1ENR, USART2);
             break;
+        case PERIPH_TIM2:
+            SET_BIT(RCC->APB1ENR, TIM2);
+            break;
 
         // APB2 Bus
         case PERIPH_USART1:

--- a/src/TIM2_program.c
+++ b/src/TIM2_program.c
@@ -14,20 +14,46 @@ static void (*TIM2_INT_POINTER)(void) = NULL;
 
 void TIM2_Peripheral_Init()
 {
-    /*__________ENABLE ARR REGISTER_________*/
+	/*__________ENABLE ARR REGISTER_________*/
 	SET_BIT(TIM2->CR1, ARPE);
 	/*________SELECT COUNT DIRECTION________*/
-    CLEAR_BIT(TIM2->CR1, DIR);
-    TIM2->CR1 |= (TIMER_DIRECTION<<DIR);
-    /*________UPDATE REQUEST SOURCE_________*/
-    SET_BIT(TIM2->CR1, URS); // -> Update source set to overflow or underflow only
-    /*________LOAD PRESCALAR VALUE__________*/
-    TIM2->PSC = PRESCALAR;
+	CLEAR_BIT(TIM2->CR1, DIR);
+	TIM2->CR1 |= (TIMER_DIRECTION<<DIR);
+	/*________UPDATE REQUEST SOURCE_________*/
+	SET_BIT(TIM2->CR1, URS); // -> Update source set to overflow or underflow only
+	/*________LOAD PRESCALAR VALUE__________*/
+	TIM2->PSC = PRESCALAR;
 }
+
+void TIM2_Delay_ms(u32_t Load)
+{
+	//Set Timer to count one time and stop
+	SET_BIT(TIM2->CR1, OPM);
+	//set value
+	TIM2->ARR = ((Load*1000)-1);
+	//Start Timer
+	SET_BIT(TIM2->EGR, UG);
+	SET_BIT(TIM2->CR1, CEN);
+
+}
+
+void TIM2_Delay_us(u32_t Load)
+{
+	//set value
+	TIM2->ARR = (Load-1);
+	//Reset the timer
+	TIM2->CNT = 0;
+	//Set Timer to count one time and stop
+	SET_BIT(TIM2->CR1, OPM);
+	//Start Timer
+	SET_BIT(TIM2->EGR, UG);
+	SET_BIT(TIM2->CR1, CEN);
+}
+
 void TIM2_Start_Timer()
 {
 	SET_BIT(TIM2->EGR, UG);
-    SET_BIT(TIM2->CR1, CEN);
+	SET_BIT(TIM2->CR1, CEN);
 }
 void TIM2_Stop_Timer()
 {
@@ -35,27 +61,27 @@ void TIM2_Stop_Timer()
 }
 void TIM2_Interrupt_Enable()
 {
-    SET_BIT(TIM2->DIER, UIE);
+	SET_BIT(TIM2->DIER, UIE);
 }
 void TIM2_Call_Back_Function(void (*ptr)(void))
 {
-    if(ptr!=NULL){
-    	TIM2_INT_POINTER = ptr;
-    }
+	if(ptr!=NULL){
+		TIM2_INT_POINTER = ptr;
+	}
 }
 void TIM2_IRQHandler(void)
 {
-    if(TIM2_INT_POINTER!= NULL){
-    	TIM2_INT_POINTER();
-    }
+	if(TIM2_INT_POINTER!= NULL){
+		TIM2_INT_POINTER();
+	}
 }
 void TIM2_Preload_Value(u32_t PRELOAD)
 {
-    TIM2->ARR = PRELOAD;
+	TIM2->ARR = PRELOAD;
 }
 void TIM2_Clear_Interrupt_Flag()
 {
-    CLEAR_BIT(TIM2->SR, UIF);
+	CLEAR_BIT(TIM2->SR, UIF);
 }
 u8_t TIM2_Read_Interrupt_Flag()
 {

--- a/src/UART_program.c
+++ b/src/UART_program.c
@@ -21,7 +21,8 @@ void UART1_Peripheral_init()
 	/*_________ENABLE_________*/
 	UART1->CR1.TE=1;
 	UART1->CR1.RE=1;
-	SET_BIT(UART1->CR3, 7);
+//	SET_BIT(UART1->CR3, 7);
+//	SET_BIT(UART1->CR3, 6);
     /*________BAUD RATE________*/
 	UART1->BRR = (104<<4)|(3);
 	/*_______UART ENABLE_______*/


### PR DESCRIPTION
- Added DFPlayer drivers.
- Added two delay functions.
- Set TIM2 prescaler to 15.
- Enabled TIM2 clock on APB1 in RCC.
- In UART module, commented out two lines in Init function to disable DMA transmit.

- Tarek's part
